### PR TITLE
add leiningen plugin

### DIFF
--- a/lein-nightlight/project.clj
+++ b/lein-nightlight/project.clj
@@ -1,0 +1,10 @@
+(defproject nightlight/lein-nightlight "1.0.0"
+  :description "A conveninent Nightlight launcher for Leiningen projects"
+  :url "https://github.com/oakes/Nightlight"
+  :license {:name "Public domain"
+            :url "http://unlicense.org/UNLICENSE"}
+  :dependencies [[nightlight "1.0.0"]
+                 [leinjacker "0.4.2"]
+                 [org.clojure/tools.cli "0.3.5"]]
+  :eval-in-leiningen true)
+

--- a/lein-nightlight/src/leiningen/nightlight.clj
+++ b/lein-nightlight/src/leiningen/nightlight.clj
@@ -1,0 +1,41 @@
+(ns leiningen.nightlight
+  (:require
+    [leinjacker.deps :as deps]
+    [leinjacker.eval :as eval]
+    [clojure.tools.cli :as cli]))
+
+
+(def cli-options
+  [["-p" "--port PORT" "Port number"
+    :default 4000
+    :parse-fn #(Integer/parseInt %)
+    :validate [#(< 0 % 0x10000) "Must be an integer between 0 and 65536"]]
+   ["-u" "--usage" "Show CLI usage options"]])
+
+
+(defn start-nightlight
+  [project port]
+  (eval/eval-in-project
+    (deps/add-if-missing
+      project
+      '[nightlight/lein-nightlight "1.0.0"])
+    `(nightlight.core/start {:port ~port})
+    `(require 'nightlight.core)))
+
+
+(defn nightlight
+  "A conveninent Nightlife launcher
+  Run with -u to see CLI usage."
+  [project & args]
+  (let [cli (cli/parse-opts args cli-options)]
+    (cond
+      ;; if there are CLI errors, print error messages and usage summary
+      (:errors cli)
+      (println (:errors cli) "\n" (:summary cli))
+      ;; if user asked for CLI usage, print the usage summary
+      (get-in cli [:options :usage])
+      (println (:summary cli))
+      ;; in other cases start Nightlight
+      :otherwise
+      (start-nightlight project (get-in cli [:options :port])))))
+


### PR DESCRIPTION
This PR adds a sub-project to create a Leiningen plugin to launch Nightlight. The project (the one user wants to edit with Nightlight) need not know the existence of Nightlight -- the user can add the plugin to `~/.lein/profiles.clj` as follows:

``` clojure
{:user {:plugins [[nightlight/lein-nightlight "1.0.0"]]}}
```

This PR has kept the versions to `1.0.0` and the default port number to `4000` (as `3000` is commonly used by many projects for web development). Please feel free to edit the details as required.
