### PR TITLE
Sort directories and files alphabetically

### DIFF
--- a/src/cljs/nightlight/components.cljs
+++ b/src/cljs/nightlight/components.cljs
@@ -155,7 +155,9 @@
 (defn node->element [editable? {:keys [nested-items] :as node}]
   (let [node (cond
                (seq nested-items)
-               (assoc node :nested-items (mapv (partial node->element editable?) nested-items))
+               (assoc node :nested-items (->> nested-items
+                                              (sort-by :primary-text)
+                                              (mapv (partial node->element editable?))))
                (and editable?
                     (-> @s/runtime-state :options :read-only? not))
                (assoc node :right-icon-button (icon-button node))
@@ -184,6 +186,7 @@
                            (remove nil?)
                            (map (partial node->element false)))
          nodes (->> nodes
+                    (sort-by :primary-text)
                     (map (partial node->element true))
                     (concat header-nodes))]
      (vec


### PR DESCRIPTION
This very small change displays the directories and files of the side-bar in alphabetical order. This makes file navigation a lot easier when there many files in a directory for example.

A thing to note is that the sorting added by this PR (which is clojurescript's default sorting for strings) is case sensitive. That means that names that begins with a capitalized Letter will be first in the list. For example, applied to this repository file structure:

```
README.md
UNLICENSE
boot.properties
build.boot
dev-resources
lein-nightlight
prod-resources
resources
screenshot.png
src
target
```

I consider it a feature, as it makes files like READMEs and licences go first. Let me know what you think!